### PR TITLE
fix: support status='*' to list all work packages including closed ones

### DIFF
--- a/src/openproject_mcp/server.py
+++ b/src/openproject_mcp/server.py
@@ -41,14 +41,15 @@ async def list_tools() -> list[types.Tool]:
             name="list_work_packages",
             description=(
                 "List work packages with optional filters. Use stale_days to find tasks "
-                "not updated recently. Use assignee_id='me' for current user's tasks."
+                "not updated recently. Use assignee_id='me' for current user's tasks. "
+                "By default OpenProject only returns open work packages; pass status='*' to include all statuses (open and closed)."
             ),
             inputSchema={
                 "type": "object",
                 "properties": {
                     "project_id": {"type": "string", "description": "Filter by project ID or identifier"},
                     "assignee_id": {"type": "string", "description": "Filter by assignee user ID or 'me'"},
-                    "status": {"type": "string", "description": "Filter by status name, e.g. 'New', 'In progress'"},
+                    "status": {"type": "string", "description": "Filter by status name, e.g. 'New', 'In progress', 'Closed'. Use '*' to include all statuses (open and closed). By default OpenProject only returns open work packages."},
                     "type_name": {"type": "string", "description": "Filter by type name, e.g. 'Task', 'Bug'"},
                     "stale_days": {"type": "integer", "description": "Only return WPs not updated in N days"},
                 },

--- a/src/openproject_mcp/tools/work_packages.py
+++ b/src/openproject_mcp/tools/work_packages.py
@@ -65,7 +65,10 @@ def list_work_packages(
         filters.append({"assignee": {"operator": "=", "values": [str(assignee_id)]}})
 
     if status:
-        filters.append({"status": {"operator": "=", "values": [status]}})
+        if status == "*":
+            filters.append({"status": {"operator": "*", "values": []}})
+        else:
+            filters.append({"status": {"operator": "=", "values": [status]}})
 
     if type_name:
         filters.append({"type": {"operator": "=", "values": [type_name]}})


### PR DESCRIPTION
Fixes #1

## Summary

- `list_work_packages` now accepts `status='*'` to retrieve work packages of **all statuses**, including closed ones
- When `status='*'` is passed, the correct OpenProject API operator (`{"operator": "*", "values": []}`) is used instead of the equality operator
- Tool description and parameter description updated so AI agents know the default is "open only" and that `'*'` overrides it

## Changes

**`src/openproject_mcp/tools/work_packages.py`**
```python
if status == "*":
    filters.append({"status": {"operator": "*", "values": []}})
else:
    filters.append({"status": {"operator": "=", "values": [status]}})
```

**`src/openproject_mcp/server.py`** — updated descriptions:
- Tool description: *"By default OpenProject only returns open work packages; pass status='*' to include all statuses (open and closed)."*
- Parameter description: *"Use '*' to include all statuses (open and closed). By default OpenProject only returns open work packages."*

## Test plan

- [ ] Call `list_work_packages()` without status → only open WPs returned (unchanged behaviour)
- [ ] Call `list_work_packages(status='*')` → all WPs returned including closed
- [ ] Call `list_work_packages(status='Closed')` → only closed WPs returned (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)