### PR TITLE
feat: add tools to manage relations between work packages

### DIFF
--- a/src/openproject_mcp/client.py
+++ b/src/openproject_mcp/client.py
@@ -49,6 +49,11 @@ class OpenProjectClient:
         response.raise_for_status()
         return response.json()
 
+    def delete(self, path: str) -> None:
+        url = urljoin(self.base_url + "/", f"api/v3/{path.lstrip('/')}")
+        response = self.session.delete(url)
+        response.raise_for_status()
+
     def get_all(self, path: str, params: dict | None = None) -> list[dict]:
         """Fetch all pages of a collection endpoint."""
         params = params or {}

--- a/src/openproject_mcp/server.py
+++ b/src/openproject_mcp/server.py
@@ -150,6 +150,71 @@ async def list_tools() -> list[types.Tool]:
             description="List work package priorities (Low, Normal, High, Immediate).",
             inputSchema={"type": "object", "properties": {}, "required": []},
         ),
+        types.Tool(
+            name="list_relations",
+            description=(
+                "List relations between work packages with optional filters. "
+                "Use involved_id to get all relations of a given work package."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "from_id": {"type": "integer", "description": "Filter by the work package from which the relation emanates"},
+                    "to_id": {"type": "integer", "description": "Filter by the work package to which the relation points"},
+                    "involved_id": {"type": "integer", "description": "Filter by a WP that is either from or to"},
+                    "relation_type": {
+                        "type": "string",
+                        "description": "Filter by relation type: relates, duplicates, duplicated, blocks, blocked, precedes, follows, includes, partof, requires, required",
+                    },
+                    "sort_by": {"type": "string", "description": 'Sort spec JSON, e.g. \'[["type","asc"]]\''},
+                },
+                "required": [],
+            },
+        ),
+        types.Tool(
+            name="create_relation",
+            description=(
+                "Create a relation between two work packages. "
+                "Supported types: relates, duplicates, duplicated, blocks, blocked, "
+                "precedes, follows, includes, partof, requires, required."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "from_id": {"type": "integer", "description": "ID of the work package from which the relation emanates"},
+                    "to_id": {"type": "integer", "description": "ID of the work package to which the relation points"},
+                    "relation_type": {"type": "string", "description": "Type of relation, e.g. 'blocks', 'precedes', 'relates'"},
+                    "description": {"type": "string", "description": "Optional description of the relation"},
+                    "lag": {"type": "integer", "description": "Days between closure of `from` and start of `to` (for precedes/follows)"},
+                },
+                "required": ["from_id", "to_id", "relation_type"],
+            },
+        ),
+        types.Tool(
+            name="update_relation",
+            description="Update an existing relation (type, description, or lag). Only provided fields are changed.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "relation_id": {"type": "integer", "description": "ID of the relation to update"},
+                    "relation_type": {"type": "string", "description": "New relation type"},
+                    "description": {"type": "string", "description": "New description"},
+                    "lag": {"type": "integer", "description": "New lag in days"},
+                },
+                "required": ["relation_id"],
+            },
+        ),
+        types.Tool(
+            name="delete_relation",
+            description="Delete a relation between work packages by its relation ID.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "relation_id": {"type": "integer", "description": "ID of the relation to delete"},
+                },
+                "required": ["relation_id"],
+            },
+        ),
     ]
 
 
@@ -181,6 +246,14 @@ async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
                 return ok(meta.list_types(client, arguments.get("project_id")))
             case "list_priorities":
                 return ok(meta.list_priorities(client))
+            case "list_relations":
+                return ok(work_packages.list_relations(client, **arguments))
+            case "create_relation":
+                return ok(work_packages.create_relation(client, **arguments))
+            case "update_relation":
+                return ok(work_packages.update_relation(client, **arguments))
+            case "delete_relation":
+                return ok(work_packages.delete_relation(client, arguments["relation_id"]))
             case _:
                 return err(ValueError(f"Unknown tool: {name}"))
     except Exception as e:

--- a/src/openproject_mcp/tools/work_packages.py
+++ b/src/openproject_mcp/tools/work_packages.py
@@ -231,3 +231,135 @@ def add_comment(client: OpenProjectClient, work_package_id: int, comment: str) -
         "comment": result.get("comment", {}).get("raw", ""),
         "created_at": result.get("createdAt", ""),
     }
+
+
+# ---------------------------------------------------------------------------
+# Relations
+# ---------------------------------------------------------------------------
+
+RELATION_TYPES = (
+    "relates",
+    "duplicates",
+    "duplicated",
+    "blocks",
+    "blocked",
+    "precedes",
+    "follows",
+    "includes",
+    "partof",
+    "requires",
+    "required",
+)
+
+
+def _format_relation(rel: dict) -> dict:
+    links = rel.get("_links", {})
+    return {
+        "id": rel["id"],
+        "type": rel.get("type", ""),
+        "reverse_type": rel.get("reverseType", ""),
+        "description": rel.get("description", ""),
+        "lag": rel.get("lag", 0),
+        "from_id": _extract_id(links.get("from", {}).get("href", "")),
+        "from_subject": links.get("from", {}).get("title", ""),
+        "to_id": _extract_id(links.get("to", {}).get("href", "")),
+        "to_subject": links.get("to", {}).get("title", ""),
+    }
+
+
+def list_relations(
+    client: OpenProjectClient,
+    from_id: int | None = None,
+    to_id: int | None = None,
+    involved_id: int | None = None,
+    relation_type: str | None = None,
+    sort_by: str | None = None,
+) -> list[dict]:
+    """
+    List relations with optional filters.
+
+    - from_id: filter by the work package from which the relation emanates
+    - to_id: filter by the work package to which the relation points
+    - involved_id: filter by a WP that is either from or to
+    - relation_type: filter by type, e.g. 'blocks', 'precedes', 'relates'
+    - sort_by: JSON sort spec, e.g. '[["type","asc"]]'
+    """
+    import json
+
+    filters = []
+    if from_id is not None:
+        filters.append({"from": {"operator": "=", "values": [str(from_id)]}})
+    if to_id is not None:
+        filters.append({"to": {"operator": "=", "values": [str(to_id)]}})
+    if involved_id is not None:
+        filters.append({"involved": {"operator": "=", "values": [str(involved_id)]}})
+    if relation_type is not None:
+        filters.append({"type": {"operator": "=", "values": [relation_type]}})
+
+    params: dict[str, Any] = {}
+    if filters:
+        params["filters"] = json.dumps(filters)
+    if sort_by:
+        params["sortBy"] = sort_by
+
+    rels = client.get_all("relations", params)
+    return [_format_relation(r) for r in rels]
+
+
+def create_relation(
+    client: OpenProjectClient,
+    from_id: int,
+    to_id: int,
+    relation_type: str,
+    description: str = "",
+    lag: int = 0,
+) -> dict:
+    """
+    Create a relation between two work packages.
+
+    - relation_type: one of relates, duplicates, duplicated, blocks, blocked,
+                     precedes, follows, includes, partof, requires, required
+    - lag: days between the closure of `from` and the start of `to` (precedes/follows)
+    """
+    data: dict[str, Any] = {
+        "type": relation_type,
+        "description": description,
+        "lag": lag,
+        "_links": {
+            "from": {"href": f"/api/v3/work_packages/{from_id}"},
+            "to": {"href": f"/api/v3/work_packages/{to_id}"},
+        },
+    }
+    result = client.post(f"work_packages/{from_id}/relations", data)
+    return _format_relation(result)
+
+
+def update_relation(
+    client: OpenProjectClient,
+    relation_id: int,
+    relation_type: str | None = None,
+    description: str | None = None,
+    lag: int | None = None,
+) -> dict:
+    """
+    Update an existing relation. Only provided fields are changed.
+
+    - relation_type: new type, e.g. 'blocks'
+    - lag: new lag in days
+    """
+    data: dict[str, Any] = {}
+    if relation_type is not None:
+        data["type"] = relation_type
+    if description is not None:
+        data["description"] = description
+    if lag is not None:
+        data["lag"] = lag
+
+    result = client.patch(f"relations/{relation_id}", data)
+    return _format_relation(result)
+
+
+def delete_relation(client: OpenProjectClient, relation_id: int) -> dict:
+    """Delete a relation by its ID."""
+    client.delete(f"relations/{relation_id}")
+    return {"deleted": True, "relation_id": relation_id}


### PR DESCRIPTION
## Summary

- Adds 4 new MCP tools to manage relations between work packages via the OpenProject REST API
- Adds `OpenProjectClient.delete()` to support the new `DELETE` endpoint

## New tools

| Tool | API endpoint | Description |
|---|---|---|
| `list_relations` | `GET /api/v3/relations` | List relations with filters (`from_id`, `to_id`, `involved_id`, `type`, `sort_by`) |
| `create_relation` | `POST /api/v3/work_packages/{id}/relations` | Create a relation between two WPs |
| `update_relation` | `PATCH /api/v3/relations/{id}` | Update type, description, or lag |
| `delete_relation` | `DELETE /api/v3/relations/{id}` | Delete a relation |

## Supported relation types

`relates` · `duplicates` · `duplicated` · `blocks` · `blocked` · `precedes` · `follows` · `includes` · `partof` · `requires` · `required`

## Dependencies

Depends on #6 — unit tests for these tools will be added to this branch once the test infrastructure is merged.

## Test plan

- [ ] `list_relations` with no filter returns all relations
- [ ] `list_relations` filtered by `involved_id` returns only relations involving that WP
- [ ] `create_relation` with type `blocks` links two WPs correctly
- [ ] `update_relation` changes the type of an existing relation
- [ ] `delete_relation` removes the relation

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)