### PR TITLE
chore: ignore CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 dist/
 build/
 .pytest_cache/
+CLAUDE.md


### PR DESCRIPTION
## Summary

Adds `CLAUDE.md` to `.gitignore`.

## Rationale

`CLAUDE.md` contains contributor-specific AI assistant instructions: local file paths, personal project context, NDA-sensitive information. It is analogous to a `.env` file — each contributor maintains their own local copy and it should never be committed to the shared repository.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)