### PR TITLE
fix: add parent_id support to update_work_package

### DIFF
--- a/src/openproject_mcp/server.py
+++ b/src/openproject_mcp/server.py
@@ -95,6 +95,7 @@ async def list_tools() -> list[types.Tool]:
                     "description": {"type": "string", "description": "Markdown description"},
                     "status_id": {"type": "integer", "description": "New status ID (from list_statuses)"},
                     "assignee_id": {"type": "integer", "description": "New assignee user ID"},
+                    "parent_id": {"type": "integer", "description": "New parent work package ID (use 0 to remove parent)"},
                     "percent_done": {"type": "integer", "description": "Completion percentage 0-100"},
                     "estimated_hours": {"type": "number"},
                     "remaining_hours": {"type": "number"},

--- a/src/openproject_mcp/tools/work_packages.py
+++ b/src/openproject_mcp/tools/work_packages.py
@@ -186,6 +186,7 @@ def update_work_package(
     description: str | None = None,
     status_id: int | None = None,
     assignee_id: int | None = None,
+    parent_id: int | None = None,
     percent_done: int | None = None,
     estimated_hours: float | None = None,
     remaining_hours: float | None = None,
@@ -195,6 +196,7 @@ def update_work_package(
     Update a work package. Only provided fields are changed.
 
     - status_id: get valid IDs from list_statuses()
+    - parent_id: move the WP under a new parent (set to 0 to remove the parent)
     - percent_done: 0-100
     """
     # Must include lockVersion to avoid conflict errors
@@ -209,6 +211,9 @@ def update_work_package(
         data["_links"]["status"] = {"href": f"/api/v3/statuses/{status_id}"}
     if assignee_id is not None:
         data["_links"]["assignee"] = {"href": f"/api/v3/users/{assignee_id}"}
+    if parent_id is not None:
+        href = f"/api/v3/work_packages/{parent_id}" if parent_id != 0 else None
+        data["_links"]["parent"] = {"href": href}
     if percent_done is not None:
         data["percentageDone"] = percent_done
     if estimated_hours is not None:


### PR DESCRIPTION
## Problem

`update_work_package` did not expose `parent_id` as a parameter, making it impossible for an agent to move a work package under a different parent via the MCP.

The OpenProject REST API v3 supports this via a standard `PATCH /api/v3/work_packages/:id` with `_links.parent.href`.

## Fix

Added `parent_id` as an optional parameter to both the tool function and its MCP schema. It is serialized as `_links.parent.href` (not as a top-level field):

```json
{
  "_links": { "parent": { "href": "/api/v3/work_packages/65" } },
  "lockVersion": 3
}
```

Setting `parent_id=0` sends `href: null`, which detaches the work package from its current parent.

## Dependencies

Depends on #6 — unit tests for this fix will be added to this branch once the test infrastructure is merged.

## Test plan

- [ ] `update_work_package(id=X, parent_id=65)` moves WP X under WP 65
- [ ] `update_work_package(id=X, parent_id=0)` detaches WP X from its parent

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)