### PR TITLE
fix: add start_date support to update_work_package

### DIFF
--- a/src/openproject_mcp/server.py
+++ b/src/openproject_mcp/server.py
@@ -98,6 +98,7 @@ async def list_tools() -> list[types.Tool]:
                     "percent_done": {"type": "integer", "description": "Completion percentage 0-100"},
                     "estimated_hours": {"type": "number"},
                     "remaining_hours": {"type": "number"},
+                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD"},
                     "due_date": {"type": "string", "description": "Due date YYYY-MM-DD"},
                 },
                 "required": ["id"],

--- a/src/openproject_mcp/tools/work_packages.py
+++ b/src/openproject_mcp/tools/work_packages.py
@@ -189,6 +189,7 @@ def update_work_package(
     percent_done: int | None = None,
     estimated_hours: float | None = None,
     remaining_hours: float | None = None,
+    start_date: str | None = None,
     due_date: str | None = None,
 ) -> dict:
     """
@@ -196,6 +197,7 @@ def update_work_package(
 
     - status_id: get valid IDs from list_statuses()
     - percent_done: 0-100
+    - start_date / due_date: YYYY-MM-DD
     """
     # Must include lockVersion to avoid conflict errors
     current = client.get(f"work_packages/{id}")
@@ -215,6 +217,8 @@ def update_work_package(
         data["estimatedTime"] = f"PT{int(estimated_hours)}H{int((estimated_hours % 1) * 60)}M"
     if remaining_hours is not None:
         data["remainingTime"] = f"PT{int(remaining_hours)}H{int((remaining_hours % 1) * 60)}M"
+    if start_date is not None:
+        data["startDate"] = start_date
     if due_date is not None:
         data["dueDate"] = due_date
 


### PR DESCRIPTION
## Problem

`start_date` was already supported by `create_work_package` but was silently ignored by `update_work_package` — neither the function signature nor the MCP tool schema exposed it, making it impossible for an agent to set or change the start date of an existing work package.

## Fix

Added `start_date: str | None = None` (format `YYYY-MM-DD`) to both the function and the MCP schema, serialized as `startDate` in the PATCH body — consistent with how `due_date` is handled.

## Dependencies

Depends on #6 — unit tests for this fix will be added to this branch once the test infrastructure is merged.

## Test plan

- [ ] `update_work_package(id=X, start_date="2026-03-01")` correctly updates the start date
- [ ] `update_work_package(id=X, due_date="2026-03-31")` still works (non-regression)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)