### PR TITLE
feat: add category support

### DIFF
--- a/src/openproject_mcp/server.py
+++ b/src/openproject_mcp/server.py
@@ -76,6 +76,7 @@ async def list_tools() -> list[types.Tool]:
                     "description": {"type": "string", "description": "Markdown description"},
                     "assignee_id": {"type": "integer", "description": "User ID to assign to"},
                     "parent_id": {"type": "integer", "description": "Parent work package ID (for subtasks)"},
+                    "category_id": {"type": "integer", "description": "Category ID (from list_categories)"},
                     "estimated_hours": {"type": "number", "description": "Estimated hours, e.g. 2.5"},
                     "priority_id": {"type": "integer", "description": "Priority ID (from list_priorities)"},
                     "start_date": {"type": "string", "description": "Start date YYYY-MM-DD"},
@@ -95,6 +96,7 @@ async def list_tools() -> list[types.Tool]:
                     "description": {"type": "string", "description": "Markdown description"},
                     "status_id": {"type": "integer", "description": "New status ID (from list_statuses)"},
                     "assignee_id": {"type": "integer", "description": "New assignee user ID"},
+                    "category_id": {"type": "integer", "description": "New category ID (from list_categories)"},
                     "percent_done": {"type": "integer", "description": "Completion percentage 0-100"},
                     "estimated_hours": {"type": "number"},
                     "remaining_hours": {"type": "number"},
@@ -150,6 +152,17 @@ async def list_tools() -> list[types.Tool]:
             description="List work package priorities (Low, Normal, High, Immediate).",
             inputSchema={"type": "object", "properties": {}, "required": []},
         ),
+        types.Tool(
+            name="list_categories",
+            description="List work package categories for a project. Use category IDs with create_work_package and update_work_package.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "project_id": {"type": "string", "description": "Project ID or identifier"},
+                },
+                "required": ["project_id"],
+            },
+        ),
     ]
 
 
@@ -181,6 +194,8 @@ async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
                 return ok(meta.list_types(client, arguments.get("project_id")))
             case "list_priorities":
                 return ok(meta.list_priorities(client))
+            case "list_categories":
+                return ok(meta.list_categories(client, arguments["project_id"]))
             case _:
                 return err(ValueError(f"Unknown tool: {name}"))
     except Exception as e:

--- a/src/openproject_mcp/tools/meta.py
+++ b/src/openproject_mcp/tools/meta.py
@@ -43,3 +43,16 @@ def list_priorities(client: OpenProjectClient) -> list[dict]:
         }
         for p in priorities
     ]
+
+
+def list_categories(client: OpenProjectClient, project_id: str | int) -> list[dict]:
+    """List work package categories for a project."""
+    categories = client.get_all(f"projects/{project_id}/categories")
+    return [
+        {
+            "id": c["id"],
+            "name": c["name"],
+            "default_assignee": c.get("_links", {}).get("defaultAssignee", {}).get("title", ""),
+        }
+        for c in categories
+    ]

--- a/src/openproject_mcp/tools/work_packages.py
+++ b/src/openproject_mcp/tools/work_packages.py
@@ -20,6 +20,8 @@ def _format_wp(wp: dict) -> dict:
         "author": links.get("author", {}).get("title", ""),
         "project": links.get("project", {}).get("title", ""),
         "parent_id": _extract_id(links.get("parent", {}).get("href", "")),
+        "category_id": _extract_id(links.get("category", {}).get("href", "")),
+        "category": links.get("category", {}).get("title", ""),
         "percent_done": wp.get("percentageDone", 0),
         "estimated_hours": wp.get("estimatedTime"),
         "remaining_hours": wp.get("remainingTime"),
@@ -141,6 +143,7 @@ def create_work_package(
     description: str = "",
     assignee_id: int | None = None,
     parent_id: int | None = None,
+    category_id: int | None = None,
     estimated_hours: float | None = None,
     priority_id: int | None = None,
     start_date: str | None = None,
@@ -150,6 +153,7 @@ def create_work_package(
     Create a new work package (task, subtask, bug, etc.).
 
     - parent_id: set to make this a subtask of another work package
+    - category_id: get valid IDs from list_categories()
     - type_id: get valid IDs from list_types()
     - estimated_hours: e.g. 2.5 for 2h 30m
     """
@@ -166,6 +170,8 @@ def create_work_package(
         data["_links"]["assignee"] = {"href": f"/api/v3/users/{assignee_id}"}
     if parent_id:
         data["_links"]["parent"] = {"href": f"/api/v3/work_packages/{parent_id}"}
+    if category_id:
+        data["_links"]["category"] = {"href": f"/api/v3/categories/{category_id}"}
     if priority_id:
         data["_links"]["priority"] = {"href": f"/api/v3/priorities/{priority_id}"}
     if estimated_hours is not None:
@@ -186,6 +192,7 @@ def update_work_package(
     description: str | None = None,
     status_id: int | None = None,
     assignee_id: int | None = None,
+    category_id: int | None = None,
     percent_done: int | None = None,
     estimated_hours: float | None = None,
     remaining_hours: float | None = None,
@@ -195,6 +202,7 @@ def update_work_package(
     Update a work package. Only provided fields are changed.
 
     - status_id: get valid IDs from list_statuses()
+    - category_id: get valid IDs from list_categories()
     - percent_done: 0-100
     """
     # Must include lockVersion to avoid conflict errors
@@ -209,6 +217,8 @@ def update_work_package(
         data["_links"]["status"] = {"href": f"/api/v3/statuses/{status_id}"}
     if assignee_id is not None:
         data["_links"]["assignee"] = {"href": f"/api/v3/users/{assignee_id}"}
+    if category_id is not None:
+        data["_links"]["category"] = {"href": f"/api/v3/categories/{category_id}"}
     if percent_done is not None:
         data["percentageDone"] = percent_done
     if estimated_hours is not None:


### PR DESCRIPTION
## Summary

Categories were entirely absent from the MCP. This PR fixes three gaps simultaneously.

## Changes

### 1. New tool — `list_categories(project_id)`
Lists available categories for a project via `GET /api/v3/projects/{id}/categories`.
Returns `id`, `name`, and `default_assignee` for each category.

> **Note on deprecated endpoint:** The official replacement is `GET /api/v3/workspaces/{id}/categories`, but workspace IDs differ from project IDs and require an undocumented extra call to resolve. The deprecated project endpoint is still functional, has no announced removal date, and is the pragmatic choice here.

### 2. `_format_wp` now exposes category
`category_id` and `category` (name) are extracted from `_links.category` and included in all work package responses.

### 3. `category_id` in create and update
Both `create_work_package` and `update_work_package` accept an optional `category_id`, serialized as `_links.category.href` per the REST API v3 spec.

## Dependencies

Depends on #6 — unit tests will be added once the test infrastructure is merged.

## Test plan

- [ ] `list_categories(project_id=X)` returns categories with correct IDs and names
- [ ] `get_work_package` response includes `category_id` and `category` fields
- [ ] `create_work_package(..., category_id=Y)` assigns the category
- [ ] `update_work_package(id=X, category_id=Y)` changes the category

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)